### PR TITLE
Prepare 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.4.1](https://github.com/sdb9696/firebase-messaging/tree/0.4.1) (2024-09-06)
+
+[Full Changelog](https://github.com/sdb9696/firebase-messaging/compare/0.4.0...0.4.1)
+
+**Release highlights:**
+
+Migration to uv for project/package management
+
+**Project maintenance:**
+
+- Migrate from poetry to uv and enable testpypi publishing [\#9](https://github.com/sdb9696/firebase-messaging/pull/9) (@sdb9696)
+
 ## [0.4.0](https://github.com/sdb9696/firebase-messaging/tree/0.4.0) (2024-08-29)
 
 [Full Changelog](https://github.com/sdb9696/firebase-messaging/compare/0.3.0...0.4.0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "firebase-messaging"
-version = "0.4.0"
+version = "0.4.1"
 description = "FCM/GCM push notification client"
 authors = [{ name = "sdb9696", email = "sdb9696@users.noreply.github.com" }]
 license =  { text="MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -476,7 +476,7 @@ wheels = [
 
 [[package]]
 name = "firebase-messaging"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## [0.4.1](https://github.com/sdb9696/firebase-messaging/tree/0.4.1) (2024-09-06)

[Full Changelog](https://github.com/sdb9696/firebase-messaging/compare/0.4.0...0.4.1)

**Release highlights:**

Migration to uv for project/package management

**Project maintenance:**

- Migrate from poetry to uv and enable testpypi publishing [\#9](https://github.com/sdb9696/firebase-messaging/pull/9) (@sdb9696)