### PR TITLE
Prepare 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.4.2](https://github.com/sdb9696/firebase-messaging/tree/0.4.2) (2024-09-25)
+
+[Full Changelog](https://github.com/sdb9696/firebase-messaging/compare/0.4.1...0.4.2)
+
+**Release highlights:**
+
+Upgrades protobuf dependency to 5.28.
+
+**Project maintenance:**
+
+- Update protobuf to 5.28 [\#12](https://github.com/sdb9696/firebase-messaging/pull/12) (@sdb9696)
+
 ## [0.4.1](https://github.com/sdb9696/firebase-messaging/tree/0.4.1) (2024-09-06)
 
 [Full Changelog](https://github.com/sdb9696/firebase-messaging/compare/0.4.0...0.4.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Upgrades protobuf dependency to 5.28.
 
 **Project maintenance:**
 
+- Fix publish workflow to testpypi [\#15](https://github.com/sdb9696/firebase-messaging/pull/15) (@sdb9696)
 - Update protobuf to 5.28 [\#12](https://github.com/sdb9696/firebase-messaging/pull/12) (@sdb9696)
 
 ## [0.4.1](https://github.com/sdb9696/firebase-messaging/tree/0.4.1) (2024-09-06)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "firebase-messaging"
-version = "0.4.1"
+version = "0.4.2"
 description = "FCM/GCM push notification client"
 authors = [{ name = "sdb9696", email = "sdb9696@users.noreply.github.com" }]
 license =  { text="MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -476,7 +476,7 @@ wheels = [
 
 [[package]]
 name = "firebase-messaging"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## [0.4.2](https://github.com/sdb9696/firebase-messaging/tree/0.4.2) (2024-09-25)

[Full Changelog](https://github.com/sdb9696/firebase-messaging/compare/0.4.1...0.4.2)

**Release highlights:**

Upgrades protobuf dependency to 5.28.

**Project maintenance:**

- Update protobuf to 5.28 [\#12](https://github.com/sdb9696/firebase-messaging/pull/12) (@sdb9696)