### PR TITLE
Fix publish workflow to testpypi

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -122,3 +122,4 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         repository-url: https://test.pypi.org/legacy/
+        skip-existing: true


### PR DESCRIPTION
Adds `skip-existing` to avoid errors when trying to publish the same version number with a different hash.