### PR TITLE
Prepare 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.4.3](https://github.com/sdb9696/firebase-messaging/tree/0.4.3) (2024-09-25)
+
+[Full Changelog](https://github.com/sdb9696/firebase-messaging/compare/0.4.2...0.4.3)
+
+**Release highlights:**
+
+- Suppress unnecessary warnings from dependant library.
+
+**Fixed bugs:**
+
+- Catch excessive protobuf warnings [\#16](https://github.com/sdb9696/firebase-messaging/pull/16) (@sdb9696)
+
 ## [0.4.2](https://github.com/sdb9696/firebase-messaging/tree/0.4.2) (2024-09-25)
 
 [Full Changelog](https://github.com/sdb9696/firebase-messaging/compare/0.4.1...0.4.2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "firebase-messaging"
-version = "0.4.2"
+version = "0.4.3"
 description = "FCM/GCM push notification client"
 authors = [{ name = "sdb9696", email = "sdb9696@users.noreply.github.com" }]
 license =  { text="MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -476,7 +476,7 @@ wheels = [
 
 [[package]]
 name = "firebase-messaging"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## [0.4.3](https://github.com/sdb9696/firebase-messaging/tree/0.4.3) (2024-09-25)

[Full Changelog](https://github.com/sdb9696/firebase-messaging/compare/0.4.2...0.4.3)

**Release highlights:**

- Suppress unnecessary warnings from dependant library.

**Fixed bugs:**

- Catch excessive protobuf warnings [\#16](https://github.com/sdb9696/firebase-messaging/pull/16) (@sdb9696)