### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 **Release highlights:**
 
-- Suppress unnecessary warnings from dependant library.
+- Suppress unnecessary warnings from dependent library.
 
 **Fixed bugs:**
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -104,7 +104,7 @@ Warning: PR 111 merge commit was not found in the release branch or tagged git h
 
 ```bash
 export RELEASE_NOTES=$(grep -Poz '(?<=\# Changelog\n\n)(.|\n)+?(?=\#\#)' CHANGELOG.md | tr '\0' '\n' )
-echo "$RELEASE_NOTES"  # Check the output and copy paste if neccessary
+echo "$RELEASE_NOTES"  # Check the output and copy paste if necessary
 ```
 
 ### Commit and push the changed files

--- a/firebase_messaging/fcmpushclient.py
+++ b/firebase_messaging/fcmpushclient.py
@@ -97,7 +97,7 @@ class FcmPushClientConfig:  # pylint:disable=too-many-instance-attributes
 
     send_selective_acknowledgements: bool = True
     """True to send selective acknowledgements for each message received.
-        Currently if false the client does not send any acknowlegements."""
+        Currently if false the client does not send any acknowledgements."""
 
     connection_retry_count: int = 5
     """Number of times to retry the connection before giving up."""
@@ -589,7 +589,7 @@ class FcmPushClient:  # pylint:disable=too-many-instance-attributes
                 if self._try_increment_error_count(ErrorType.LOGIN):
                     await self._reset()
             else:
-                _logger.info("Succesfully logged in to MCS endpoint")
+                _logger.info("Successfully logged in to MCS endpoint")
                 self._reset_error_count(ErrorType.LOGIN)
                 self.run_state = FcmPushClientRunState.STARTED
                 self.persistent_ids = []
@@ -608,7 +608,7 @@ class FcmPushClient:  # pylint:disable=too-many-instance-attributes
             pass
         else:
             self._log_warn_with_limit("Unexpected message type %s.", type(msg).__name__)
-        # Reset error count if a read has been succesful
+        # Reset error count if a read has been successful
         self._reset_error_count(ErrorType.READ)
         self._reset_error_count(ErrorType.CONNECTION)
 

--- a/tests/test_fcmpushclient.py
+++ b/tests/test_fcmpushclient.py
@@ -34,7 +34,7 @@ async def test_login(logged_in_push_client, fake_mcs_endpoint, mocker, caplog):
     assert (
         len([record for record in caplog.records if record.levelname == "ERROR"]) == 0
     )
-    assert "Succesfully logged in to MCS endpoint" in [
+    assert "Successfully logged in to MCS endpoint" in [
         record.message for record in caplog.records if record.levelname == "INFO"
     ]
 


### PR DESCRIPTION
Fix typos (found using `codespell`).

There are some more but I think that they are in generated files or files that are not original from firebase-messaging:

```
carles@pinux:[fix-typos]~/git/firebase-messaging$ codespell 
./firebase_messaging/proto/android_checkin_pb2.pyi:178: Miliseconds ==> Milliseconds
./firebase_messaging/proto/checkin.proto:113: supportes ==> supports
./firebase_messaging/proto/checkin_pb2.pyi:185: supportes ==> supports
./firebase_messaging/proto/android_checkin.proto:46: Miliseconds ==> Milliseconds
carles@pinux:[fix-typos]~/git/firebase-messaging$ 
```

I've checked them because I'm packaging firebase-messaging for Debian and saw one in the changelog.