### PR TITLE
Add manual github release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,7 +81,7 @@ jobs:
         name: python-package-distributions
         path: dist/
     - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v2.1.1
+      uses: sigstore/gh-action-sigstore-python@v3.0.0
       with:
         inputs: >-
           ./dist/*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,85 @@
+name: Manual PyPI Artifact Sign and Release
+
+on:
+  workflow_dispatch:
+
+env:
+  PACKAGE_NAME: firebase-messaging
+
+jobs:
+  sign-and-release:
+    if: github.repository_owner == 'sdb9696'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # IMPORTANT: mandatory for making GitHub Releases
+      id-token: write  # IMPORTANT: mandatory for sigstore
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # fetch-depth gets tags
+          fetch-depth: 0
+
+      - name: Check if latest commit is tagged
+        id: check-tag
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          TAG=$(git describe --exact-match --tags "$(git rev-parse HEAD)" 2>/dev/null || true)
+          if [[ -z "$TAG" ]]; then
+            echo "no-tag=true" >> $GITHUB_OUTPUT
+            # Get latest reachable tag
+            TAG=$(git describe --tags --abbrev=0)
+            echo "Using latest reachable tag: $TAG"
+          else
+            echo "no-tag=false" >> $GITHUB_OUTPUT
+          fi
+          echo "package-version=$TAG" >> $GITHUB_OUTPUT
+
+          RELEASE=$(gh release view "$TAG" 2>/dev/null || true)
+          if [[ -n "$RELEASE" ]]; then
+            echo "Release already exists."
+            echo "skip-create-release=true" >> $GITHUB_OUTPUT
+          fi
+      - name: Fetch PyPI artifact URLs
+        run: |
+          PACKAGE_NAME=${{ env.PACKAGE_NAME }}
+          VERSION=${{ steps.check-tag.outputs.package-version }}
+          echo "VERSION=$VERSION"
+          JSON_URL="https://pypi.org/pypi/${PACKAGE_NAME}/${VERSION}/json"
+          echo "Fetching: $JSON_URL"
+
+          urls=$(curl -s "$JSON_URL" | jq -r '.urls[].url')
+          mkdir -p dist
+          for url in $urls; do
+            echo "Downloading $url"
+            curl -sLO "$url"
+            mv "$(basename "$url")" dist/
+          done
+
+      - name: Sign the dists with Sigstore
+        uses: sigstore/gh-action-sigstore-python@v3.0.0
+        with:
+          inputs: >-
+            ./dist/*
+
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        # Repo clone is required for --notes-from-tag to work
+        if: steps.check-tag.outputs.skip-create-release != 'true'
+        run: |
+          gh release create '${{ steps.check-tag.outputs.package-version }}' --verify-tag --notes-from-tag --title '${{ steps.check-tag.outputs.package-version }}' ${{ steps.check-tag.outputs.no-tag == 'true' && '--draft' || '' }}
+
+      - name: Upload artifact signatures to GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        # Upload to GitHub Release using the `gh` CLI.
+        # `dist/` contains the built packages, and the
+        # sigstore-produced signatures and certificates.
+        run: >-
+          gh release upload
+          '${{ steps.check-tag.outputs.package-version }}' dist/**
+          --repo '${{ github.repository }}'
+          --clobber


### PR DESCRIPTION
Needed if the [Create Github Release](https://github.com/sdb9696/firebase-messaging/actions/runs/14943963346 ) step fails for any reason. In this instance it failed because sigstore/gh-action-sigstore-python@v2.1.1 was dependent on the `actions/upload-artifact@v3` which was [deprecated on 30 Jan 25](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions)