### PR TITLE
FCMPushClient._listen() waits longer for _connect_with_retry() if necessary

### DIFF
--- a/firebase_messaging/fcmpushclient.py
+++ b/firebase_messaging/fcmpushclient.py
@@ -109,6 +109,10 @@ class FcmPushClientConfig:  # pylint:disable=too-many-instance-attributes
     reset_interval: float = 3
     """Time in seconds to wait between resets after errors or disconnection."""
 
+    max_wait_in_listen_for_reset: int = 200 
+    # 200 is suitable for connection_retry_count=5 and seconds_before_retry_connect=3
+    """Time in seconds to wait in _listen() for a _reset() to succeed."""
+
     heartbeat_ack_timeout: float = 5
     """Time in seconds to wait for a heartbeat ack before resetting."""
 
@@ -683,7 +687,24 @@ class FcmPushClient:  # pylint:disable=too-many-instance-attributes
             while self.do_listen:
                 try:
                     if self.run_state == FcmPushClientRunState.RESETTING:
-                        await asyncio.sleep(1)
+                        counter = 0
+                        while (
+                            counter < FcmPushClientConfig.max_wait_in_listen_for_reset
+                            and (
+                                self.run_state == FcmPushClientRunState.RESETTING
+                                or self.run_state
+                                == FcmPushClientRunState.STARTING_CONNECTION
+                            )
+                        ):
+                            if (counter > 0) and (counter % 10 == 0):
+                                _logger.debug("Listen is waiting for reset to "
+                                f"succeed. Already slept for {counter}s, and "
+                                f"run state is still {self.run_state}.")
+                            counter = counter + 1
+                            await asyncio.sleep(1)
+                        _logger.info(
+                            f"In total listen waited {counter}s for reset "
+                            f"to succeed: run state is now {self.run_state}.")
                     elif msg := await self._receive_msg():
                         await self._handle_message(msg)
 

--- a/firebase_messaging/fcmpushclient.py
+++ b/firebase_messaging/fcmpushclient.py
@@ -110,7 +110,6 @@ class FcmPushClientConfig:  # pylint:disable=too-many-instance-attributes
     """Time in seconds to wait between resets after errors or disconnection."""
 
     max_wait_in_listen_for_reset: int = 200
-    # 200 is suitable for connection_retry_count=5 and seconds_before_retry_connect=3
     """Time in seconds to wait in _listen() for a _reset() to succeed."""
 
     heartbeat_ack_timeout: float = 5

--- a/firebase_messaging/fcmpushclient.py
+++ b/firebase_messaging/fcmpushclient.py
@@ -688,13 +688,10 @@ class FcmPushClient:  # pylint:disable=too-many-instance-attributes
                 try:
                     if self.run_state == FcmPushClientRunState.RESETTING:
                         counter = 0
-                        while (
-                            counter < FcmPushClientConfig.max_wait_in_listen_for_reset
-                            and (
-                                self.run_state == FcmPushClientRunState.RESETTING
-                                or self.run_state
-                                == FcmPushClientRunState.STARTING_CONNECTION
-                            )
+                        while counter < self.config.max_wait_in_listen_for_reset and (
+                            self.run_state == FcmPushClientRunState.RESETTING
+                            or self.run_state
+                            == FcmPushClientRunState.STARTING_CONNECTION
                         ):
                             if (counter > 0) and (counter % 10 == 0):
                                 _logger.debug(

--- a/firebase_messaging/fcmpushclient.py
+++ b/firebase_messaging/fcmpushclient.py
@@ -109,7 +109,7 @@ class FcmPushClientConfig:  # pylint:disable=too-many-instance-attributes
     reset_interval: float = 3
     """Time in seconds to wait between resets after errors or disconnection."""
 
-    max_wait_in_listen_for_reset: int = 200 
+    max_wait_in_listen_for_reset: int = 200
     # 200 is suitable for connection_retry_count=5 and seconds_before_retry_connect=3
     """Time in seconds to wait in _listen() for a _reset() to succeed."""
 
@@ -697,14 +697,17 @@ class FcmPushClient:  # pylint:disable=too-many-instance-attributes
                             )
                         ):
                             if (counter > 0) and (counter % 10 == 0):
-                                _logger.debug("Listen is waiting for reset to "
-                                f"succeed. Already slept for {counter}s, and "
-                                f"run state is still {self.run_state}.")
+                                _logger.debug(
+                                    "Listen is waiting for reset to "
+                                    f"succeed. Already slept for {counter}s, and "
+                                    f"run state is still {self.run_state}."
+                                )
                             counter = counter + 1
                             await asyncio.sleep(1)
                         _logger.info(
                             f"In total listen waited {counter}s for reset "
-                            f"to succeed: run state is now {self.run_state}.")
+                            f"to succeed: run state is now {self.run_state}."
+                        )
                     elif msg := await self._receive_msg():
                         await self._handle_message(msg)
 

--- a/firebase_messaging/fcmpushclient.py
+++ b/firebase_messaging/fcmpushclient.py
@@ -698,16 +698,31 @@ class FcmPushClient:  # pylint:disable=too-many-instance-attributes
                         ):
                             if (counter > 0) and (counter % 10 == 0):
                                 _logger.debug(
-                                    "Listen is waiting for reset to "
-                                    f"succeed. Already slept for {counter}s, and "
-                                    f"run state is still {self.run_state}."
+                                    "Listen is waiting for reset to succeed. "
+                                    "Already slept for %ss, and run state "
+                                    "is still %s.",
+                                    counter,
+                                    self.run_state,
                                 )
-                            counter = counter + 1
+                            counter += 1
                             await asyncio.sleep(1)
-                        _logger.info(
-                            f"In total listen waited {counter}s for reset "
-                            f"to succeed: run state is now {self.run_state}."
-                        )
+                        if self.run_state in (
+                            FcmPushClientRunState.RESETTING,
+                            FcmPushClientRunState.STARTING_CONNECTION,
+                        ):
+                            _logger.warning(
+                                "Listen gave up waiting for reset to succeed "
+                                "after %ss: run state is still %s.",
+                                counter,
+                                self.run_state,
+                            )
+                        else:
+                            _logger.debug(
+                                "Listen waited %ss for reset to succeed: "
+                                "run state is now %s.",
+                                counter,
+                                self.run_state,
+                            )
                     elif msg := await self._receive_msg():
                         await self._handle_message(msg)
 

--- a/firebase_messaging/fcmpushclient.py
+++ b/firebase_messaging/fcmpushclient.py
@@ -686,7 +686,10 @@ class FcmPushClient:  # pylint:disable=too-many-instance-attributes
 
             while self.do_listen:
                 try:
-                    if self.run_state == FcmPushClientRunState.RESETTING:
+                    if self.run_state in (
+                        FcmPushClientRunState.RESETTING,
+                        FcmPushClientRunState.STARTING_CONNECTION,
+                    ):
                         counter = 0
                         while counter < self.config.max_wait_in_listen_for_reset and (
                             self.run_state == FcmPushClientRunState.RESETTING

--- a/firebase_messaging/fcmregister.py
+++ b/firebase_messaging/fcmregister.py
@@ -182,7 +182,7 @@ class FcmRegister:
     async def gcm_register(
         self,
         options: dict[str, Any],
-        retries: int = 2,
+        retries: int = 4,
     ) -> dict[str, str] | None:
         """
         obtains a gcm token

--- a/tests/test_fcmpushclient.py
+++ b/tests/test_fcmpushclient.py
@@ -9,6 +9,7 @@ from cryptography.hazmat.primitives.serialization import load_der_private_key
 from http_ece import encrypt
 
 from firebase_messaging import FcmPushClient, FcmRegisterConfig
+from firebase_messaging.fcmpushclient import FcmPushClientRunState
 from firebase_messaging.proto.mcs_pb2 import (
     Close,
     DataMessageStanza,
@@ -91,6 +92,46 @@ async def test_connection_reset(logged_in_push_client, fake_mcs_endpoint, mocker
 
     msg = await fake_mcs_endpoint.get_message()
     assert isinstance(msg, LoginRequest)
+
+
+async def test_listen_wait_for_reset_timeout(
+    logged_in_push_client, fake_mcs_endpoint, caplog
+):
+    pr = await logged_in_push_client(None, None, max_wait_in_listen_for_reset=2)
+    await asyncio.sleep(0.1)
+
+    pr.run_state = FcmPushClientRunState.RESETTING
+    await fake_mcs_endpoint.put_error(ConnectionResetError())
+
+    await asyncio.sleep(2.5)
+    assert any(
+        "Listen gave up waiting for reset to succeed after 2s" in record.message
+        for record in caplog.records
+        if record.levelname == "WARNING"
+    )
+
+
+async def test_listen_wait_for_reset_success(
+    logged_in_push_client, fake_mcs_endpoint, caplog
+):
+    pr = await logged_in_push_client(None, None)
+    await asyncio.sleep(0.1)
+
+    pr.run_state = FcmPushClientRunState.RESETTING
+    await fake_mcs_endpoint.put_error(ConnectionResetError())
+
+    await asyncio.sleep(0.2)
+    pr.run_state = FcmPushClientRunState.STARTED
+
+    await asyncio.sleep(1.3)
+    assert any(
+        "Listen waited 1s for reset to succeed" in record.message
+        for record in caplog.records
+        if record.levelname == "DEBUG"
+    )
+    assert (
+        len([record for record in caplog.records if record.levelname == "WARNING"]) == 0
+    )
 
 
 @pytest.mark.parametrize("error_count", [1, 2, 3, 6])


### PR DESCRIPTION
- A reset of the fcmpushclient sometimes takes several attempts of _connect_with_retry(). The _listen() routine has to take that into account by waiting longer for _connect_with_retry(). This fixes #33
- Sometimes, gcm_register() is not successful with 'retries: int = 2,'. I suggest to increase the retries value to 4.
